### PR TITLE
fix: correct lookup field in getActiveTenantsByLandlordrename

### DIFF
--- a/src/controllers/users/landlord.ts
+++ b/src/controllers/users/landlord.ts
@@ -185,8 +185,7 @@ export const getActiveTenantsByLandlord: RequestHandler = async (req, res, next)
     const tenants = await LandlordModel.aggregate().match({ authID: id })
       .lookup({ from: "properties", localField: "authID", foreignField: "landlordAuthID", as: "properties" })
       .unwind("$properties")
-      .addFields({ "properties.id": { $toString: "$properties._id" } }) // Convertir a cadena para que la comparación sea con los mismos tipos
-      .lookup({ from: "contracts", localField: "properties.id", foreignField: "propertyId", as: "contracts" })
+      .lookup({ from: "contracts", localField: "properties._id", foreignField: "propertyId", as: "contracts" })
       .addFields({
         // Filtrar solo los contratos activos
         contracts: {


### PR DESCRIPTION
This pull request includes a change to the `getActiveTenantsByLandlord` function in `src/controllers/users/landlord.ts` to improve the accuracy of the data lookup by using the correct field type for the aggregation pipeline.

### Improvements to data lookup:
- Modified the lookup stage in `src/controllers/users/landlord.ts` to use `properties._id` directly instead of converting `_id` to a string, ensuring consistent data types for the comparison.  

**Important Note**: This change was necessary due to a recent adjustment in the database where test data was created using string IDs instead of `ObjectID` in MongoDB. Ensuring consistent ID types across the database and application is critical to avoid mismatches in queries and aggregations.