### PR TITLE
feat(property-api): implement query filters for available properties endpoint

### DIFF
--- a/src/controllers/properties/property.ts
+++ b/src/controllers/properties/property.ts
@@ -4,6 +4,7 @@ import { PropertyModel } from "../../models/properties/property";
 import { PropertyMediaModel } from "../../models/properties/propertyMedia";
 import { uploadFileS3 } from "../../utils/S3";
 import { ContractModel } from "../../models/contract/contract";
+import { applyQueryFilters } from "../../utils/mongoQueryUtils";
 
 export const createProperty: RequestHandler = async (req, res, next) => {
   const {
@@ -206,9 +207,13 @@ export const showPropertiesByUser: RequestHandler = async (req, res, next) => {
 };
 
 export const showAvailableProperties: RequestHandler = async (req, res, next) => {
+  const regexFields = ["address", "city", "state", "type", "description"];
+  const exactFields = ["rooms", "parking", "squareMeters", "tier", "bathrooms", "age", "floors", "isAvailable"];
+  const filter = applyQueryFilters(req.body, regexFields, exactFields);
+
   try {
     const properties = await PropertyModel.aggregate()
-      .match({ isAvailable: true })
+      .match({ ...filter })
       .project({ createdAt: 0, updatedAt: 0, __v: 0 }) // Retornar todo menos los timestamps y metadata de mongoose
       .lookup({ from: "propertymedias", localField: "_id", foreignField: "propertyId", as: "propertyMedia" }) // Se usa el nombre de la colección en la base de datos
       .addFields({

--- a/src/controllers/properties/property.ts
+++ b/src/controllers/properties/property.ts
@@ -4,7 +4,7 @@ import { PropertyModel } from "../../models/properties/property";
 import { PropertyMediaModel } from "../../models/properties/propertyMedia";
 import { uploadFileS3 } from "../../utils/S3";
 import { ContractModel } from "../../models/contract/contract";
-import { applyQueryFilters } from "../../utils/mongoQueryUtils";
+import { addFiltersToQuery, filterResponseByRegex, getObjectsByIds } from "../../utils/mongoQueryUtils";
 
 export const createProperty: RequestHandler = async (req, res, next) => {
   const {
@@ -209,7 +209,7 @@ export const showPropertiesByUser: RequestHandler = async (req, res, next) => {
 export const showAvailableProperties: RequestHandler = async (req, res, next) => {
   const regexFields = ["address", "city", "state", "type", "description"];
   const exactFields = ["rooms", "parking", "squareMeters", "tier", "bathrooms", "age", "floors", "isAvailable"];
-  const filter = applyQueryFilters(req.body, regexFields, exactFields);
+  const filter = addFiltersToQuery(req.body, exactFields);
 
   try {
     const properties = await PropertyModel.aggregate()
@@ -234,10 +234,15 @@ export const showAvailableProperties: RequestHandler = async (req, res, next) =>
       .sort({ createdAt: -1 })
       .exec();
 
-    if (!properties || properties.length === 0) {
+    // Se obtienen los IDs de las propiedades que cumplen con los filtros y se usara una función distinta
+    // para que las normalizaciones aplicadas a los campos de texto no afecten los resultados de la búsqueda
+    const filteredPropertiesIds = filterResponseByRegex(properties, regexFields, req.body);
+    const filteredProperties = getObjectsByIds(properties, filteredPropertiesIds);
+    if (!filteredProperties || filteredProperties.length === 0) {
       throw createHttpError(404, "No properties found");
     }
-    res.status(200).json(properties);
+
+    res.status(200).json(filteredProperties);
   } catch (error) {
     next(error);
   }

--- a/src/routes/properties/property.ts
+++ b/src/routes/properties/property.ts
@@ -56,7 +56,7 @@ const PropertyRouter = express.Router();
  */
 PropertyRouter.post("/", createProperty);
 PropertyRouter.get("/", showProperties);
-PropertyRouter.get("/available", showAvailableProperties);
+PropertyRouter.post("/available", showAvailableProperties);
 
 /**
  * @swagger

--- a/src/utils/mongoQueryUtils.ts
+++ b/src/utils/mongoQueryUtils.ts
@@ -1,17 +1,54 @@
-// TODO: Los valores en la base de datos no estan normalizados, agregar a los campos de texto la validación
-// de cadenas tomando en cuenta accentos y diacríticos.
-export const applyQueryFilters = (query: any, regexFields: string[], exactFields: string[]) => {
-  const filter: any = {};
+export const normalizeString = (str: string) => {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().trim();
+};
 
-  regexFields.forEach(field => {
-    if (query[field]) {
-      if (Array.isArray(query[field])) {
-        filter[field] = { $in: query[field].map((value: string) => new RegExp(value, "i")) };
-      } else {
-        filter[field] = { $regex: new RegExp(query[field], "i") };
+export const normalizeStrings = (strings: string[]) => {
+  return strings.map((value: string) => normalizeString(value));
+}
+
+export const createRegexFromFilter = (filter: string[] | string) => {
+  if (Array.isArray(filter)) {
+    return new RegExp(filter.join("|"), "i");
+  }
+  return new RegExp(filter, "i");
+};
+
+export const filterResponseByRegex = (responseObject: any[], fields: string[], filters: { [key: string]: string[] }) => {
+  const normalizedResponse = responseObject.map(item => {
+    const normalizedItem: any = { ...item };
+    fields.forEach(field => {
+      if (item[field]) {
+        normalizedItem[field] = normalizeString(item[field]);
       }
-    }
+    });
+    return normalizedItem;
   });
+
+  const filteredResponse = normalizedResponse.filter(item => {
+    return fields.every(field => {
+      if (filters[field]) {
+        return filters[field].some(filterValue => {
+          const regex = new RegExp(normalizeString(filterValue), "i");
+          return regex.test(item[field]);
+        });
+      }
+      return true;
+    });
+  });
+
+  return filteredResponse.map(item => item._id);
+};
+
+export const getObjectsByIds = (responseObject: any[], ids: string[]) => {
+  return responseObject.filter(item => ids.includes(item._id));
+};
+
+// TODO: Los valores en la base de datos no estan normalizados, agregar a los campos de texto la validación
+// de cadenas tomando en cuenta acentos y diacríticos.
+// -> Mientras se soluciona, el controlador de la API debe hacer la normalización de los valores de entrada
+//    antes de retornar la respuesta.
+export const addFiltersToQuery = (query: any, exactFields: string[]) => {
+  const filter: any = {};
 
   exactFields.forEach(field => {
     if (query[field]) {
@@ -25,4 +62,3 @@ export const applyQueryFilters = (query: any, regexFields: string[], exactFields
 
   return filter;
 }
-

--- a/src/utils/mongoQueryUtils.ts
+++ b/src/utils/mongoQueryUtils.ts
@@ -1,0 +1,28 @@
+// TODO: Los valores en la base de datos no estan normalizados, agregar a los campos de texto la validación
+// de cadenas tomando en cuenta accentos y diacríticos.
+export const applyQueryFilters = (query: any, regexFields: string[], exactFields: string[]) => {
+  const filter: any = {};
+
+  regexFields.forEach(field => {
+    if (query[field]) {
+      if (Array.isArray(query[field])) {
+        filter[field] = { $in: query[field].map((value: string) => new RegExp(value, "i")) };
+      } else {
+        filter[field] = { $regex: new RegExp(query[field], "i") };
+      }
+    }
+  });
+
+  exactFields.forEach(field => {
+    if (query[field]) {
+      if (Array.isArray(query[field])) {
+        filter[field] = { $in: query[field] };
+      } else {
+        filter[field] = query[field];
+      }
+    }
+  });
+
+  return filter;
+}
+


### PR DESCRIPTION
This pull request includes changes to enhance the property filtering functionality in the `properties` module. The most significant updates involve the introduction of a new utility function for applying query filters, modifications to the property controller to utilize this function, and an update to the property routes.

### Enhancements to property filtering:
- Added the `applyQueryFilters` function in `src/utils/mongoQueryUtils.ts` to handle regex and exact match filters for property queries.  
  - **Note**: A TODO has been added to normalize database values and handle text validation with support for accents and diacritics in text fields.

### Modifications to property controller:
- Imported the `applyQueryFilters` utility function in `src/controllers/properties/property.ts`.  
- Updated the `showAvailableProperties` handler to apply query filters using the new utility function.

### Updates to property routes:
- Changed the HTTP method for the `/available` endpoint in `src/routes/properties/property.ts` from `GET` to `POST` to support query filters in the request body.