### PR TITLE
feat(property-api): add endpoint to fetch properties and candidates by landlordId

### DIFF
--- a/src/routes/users/landlord.ts
+++ b/src/routes/users/landlord.ts
@@ -7,6 +7,7 @@ import {
   showLandlords,
   getActiveTenantsByLandlord,
 } from "../../controllers/users/landlord";
+import { showPropertiesAndCandidatesByLandlordId } from "../../controllers/properties/property";
 
 const LandlordRouter = express.Router();
 
@@ -162,6 +163,40 @@ LandlordRouter.delete("/:id", deleteLandlord);
  *         description: No se encontraron inquilinos activos
  */
 LandlordRouter.get("/:id/tenants/active", getActiveTenantsByLandlord);
+
+/**
+ * @swagger
+ * /api/property/landlord/{landlordId}:
+ *   get:
+ *     tags:
+ *       - Properties
+ *     summary: Obtener todas las propiedades y candidatos de un arrendador
+ *     parameters:
+ *       - in: path
+ *         name: landlordId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       '200':
+ *         description: Lista de propiedades y candidatos del arrendador
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 properties:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PropertyWithMedia'
+ *                 candidates:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Candidate'
+ *       '404':
+ *         description: No se encontraron propiedades o candidatos para el arrendador
+ */
+LandlordRouter.get("/:landlordId/candidates", showPropertiesAndCandidatesByLandlordId);
 
 export default LandlordRouter;
 


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve properties and candidates associated with a specific landlord. Additionally, it includes a minor fix in the property lookup field and updates the routing to accommodate the new functionality.

### New functionality:

* Added a new request handler `showPropertiesAndCandidatesByLandlordId` to fetch properties and candidates by landlord ID. This handler performs several MongoDB aggregations to retrieve and format the necessary data.
* Updated the `LandlordRouter` to include a new route `/api/property/landlord/{landlordId}/candidates` for fetching properties and candidates of a landlord, along with Swagger documentation for the new endpoint.

### Fixes:

* Corrected the `lookup` field in the `showAvailableProperties` method to use `property` instead of `propertyId` for consistency with the database schema.

### Imports:

* Added import for the new `showPropertiesAndCandidatesByLandlordId` handler in the `landlord` routes file.